### PR TITLE
Fix/frame titles

### DIFF
--- a/Content/Scripts/SymbolFrames/script.js
+++ b/Content/Scripts/SymbolFrames/script.js
@@ -155,7 +155,7 @@ const spanishTitleContainer = $('<div></div>')
     .addClass('passage-frames')
     .append(spanishFrameTitle);
 
-const spanishPassage = $('.thePassage .spanish').prepend(spanishTitleContainer);
+$('.thePassage .spanish').prepend(spanishTitleContainer);
 
 
 
@@ -169,7 +169,7 @@ const englishTitleContainer = $('<div></div>')
     .addClass('passage-frames')
     .append(englishFrameTitle);
 
-const englishPassage = $('.thePassage .english').prepend(englishTitleContainer);
+$('.thePassage .english').prepend(englishTitleContainer);
 
 
 

--- a/Content/Scripts/SymbolFrames/script.js
+++ b/Content/Scripts/SymbolFrames/script.js
@@ -147,29 +147,31 @@ if ($(img[0]).width()>300){
 
 /* Create container to hold Spanish symbols & frame titles */
 
-// const spanishFrameTitle = $('<p></p>')
-//     .addClass('spanish-title')
-//     .text('  ESPAÑOL');
+const spanishFrameTitle = $('<p></p>')
+    .addClass('spanish-title')
+    .text('  ESPAÑOL');
 
-// const spanishTitleContainer = $('<div></div>')
-//     .addClass('passage-frames')
-//     .append(spanishFrameTitle);
+const spanishTitleContainer = $('<div></div>')
+    .addClass('passage-frames')
+    .append(spanishFrameTitle);
 
-// const spanishPassage = $('.thePassage .spanish').prepend(spanishTitleContainer);
+const spanishPassage = $('.thePassage .spanish').prepend(spanishTitleContainer);
 
 
 
 /* Create container to hold English symbols & frame titles */
 
-// const englishFrameTitle = $('<p></p>')
-//     .addClass('english-title')
-//     .text('  ENGLISH');
+const englishFrameTitle = $('<p></p>')
+    .addClass('english-title')
+    .text('  ENGLISH');
 
-// const englishTitleContainer = $('<div></div>')
-//     .addClass('passage-frames')
-//     .append(englishFrameTitle);
+const englishTitleContainer = $('<div></div>')
+    .addClass('passage-frames')
+    .append(englishFrameTitle);
 
-// const englishPassage = $('.thePassage .english').prepend(englishTitleContainer);
+const englishPassage = $('.thePassage .english').prepend(englishTitleContainer);
+
+
 
 /* Align radio buttons with answer content */
 $('.optionContainer').css('display', 'flex').css('align-items', 'baseline');

--- a/Content/Scripts/SymbolFrames/script.js
+++ b/Content/Scripts/SymbolFrames/script.js
@@ -145,31 +145,43 @@ if ($(img[0]).width()>300){
 }
 
 
-/* Create container to hold Spanish symbols & frame titles */
 
-const spanishFrameTitle = $('<p></p>')
-    .addClass('spanish-title')
-    .text('  ESPAÑOL');
+/* Creates frame title div elem
+ * @param {string} lang - language of title
+ */
+function createFrameTitle(lang) {
+    // Create paragraph element to contain title and symbol //
+    let frameTitle;
+    if (lang === 'spanish') {
+        frameTitle = $('<p class="spanish-title">  ESPAÑOL</p>');
+    } else {
+        frameTitle = $('<p class="english-title">  ENGLISH</p>');
+    }
 
-const spanishTitleContainer = $('<div></div>')
-    .addClass('passage-frames')
-    .append(spanishFrameTitle);
+    // Create div element to contain paragraph //
+    const titleContainer = $('<div class="frames"></div>').append(frameTitle);
 
-$('.thePassage .spanish').prepend(spanishTitleContainer);
+    return titleContainer;
+}
+
+
+/* Create containers to hold Spanish symbols & frame titles */
+
+const passageSpanishTitle = createFrameTitle('spanish');
+$('.thePassage .spanish').prepend(passageSpanishTitle);
+
+const questionsSpanishTitle = createFrameTitle('spanish');
+$('.theQuestions .spanish').prepend(questionsSpanishTitle);
 
 
 
-/* Create container to hold English symbols & frame titles */
+/* Create containers to hold English symbols & frame titles */
 
-const englishFrameTitle = $('<p></p>')
-    .addClass('english-title')
-    .text('  ENGLISH');
+const passageEnglishTitle = createFrameTitle('english');
+$('.thePassage .english').prepend(passageEnglishTitle);
 
-const englishTitleContainer = $('<div></div>')
-    .addClass('passage-frames')
-    .append(englishFrameTitle);
-
-$('.thePassage .english').prepend(englishTitleContainer);
+const questionsEnglishTitle = createFrameTitle('english');
+$('.theQuestions .english').prepend(questionsEnglishTitle);
 
 
 

--- a/Content/Styles/DividedFrames/Site.scss
+++ b/Content/Styles/DividedFrames/Site.scss
@@ -127,13 +127,18 @@ html, body {
 
 %spanish-english-before-shared {
     background-color: rgb(139, 134, 134);
-    color: white;
-    font-weight: bold;
-    font-size: 20px;
-    padding: 5px 10px 5px 10px;
+    padding: 5px 16px;
     position: relative;
     bottom: 20px;
     left: 20px;
+    border-radius: 2px;
+    font-family: Verdana, sans-serif;
+    color: white;
+    font-weight: bold;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: bold;
 }
 
 .spanish::before {

--- a/Content/Styles/SymbolFrames/Site.scss
+++ b/Content/Styles/SymbolFrames/Site.scss
@@ -1,7 +1,7 @@
-$star: '\f005 \00a0 \00a0 ESPAÑOL';
-$square: '\f0c8 \00a0 \00a0 ENGLISH';
-// $star: '\f005';
-// $square: '\f0c8';
+// $star: '\f005 \00a0 \00a0 ESPAÑOL';
+// $square: '\f0c8 \00a0 \00a0 ENGLISH';
+$star: '\f005';
+$square: '\f0c8';
 $hamburger: '\f0c9';
 
 @mixin fontawesome-icon {
@@ -157,15 +157,15 @@ html, body {
   left: 20px;
 }
 
-.spanish::before {
-  @include lang-symbol(15px, $star);
-  @extend %spanish-english-before;
-}
+// .spanish::before {
+//   @include lang-symbol(15px, $star);
+//   @extend %spanish-english-before;
+// }
 
-.english::before {
-  @include lang-symbol(15px, $square);
-  @extend %spanish-english-before;
-}
+// .english::before {
+//   @include lang-symbol(15px, $square);
+//   @extend %spanish-english-before;
+// }
 
 .passage-frames {
   position: relative;

--- a/Content/Styles/SymbolFrames/Site.scss
+++ b/Content/Styles/SymbolFrames/Site.scss
@@ -1,5 +1,3 @@
-// $star: '\f005 \00a0 \00a0 ESPAÑOL';
-// $square: '\f0c8 \00a0 \00a0 ENGLISH';
 $star: '\f005';
 $square: '\f0c8';
 $hamburger: '\f0c9';
@@ -157,17 +155,7 @@ html, body {
   left: 20px;
 }
 
-// .spanish::before {
-//   @include lang-symbol(15px, $star);
-//   @extend %spanish-english-before;
-// }
-
-// .english::before {
-//   @include lang-symbol(15px, $square);
-//   @extend %spanish-english-before;
-// }
-
-.passage-frames {
+.frames {
   position: relative;
   bottom: 20px;
   left: 20px;

--- a/Content/Styles/SymbolFrames/Site.scss
+++ b/Content/Styles/SymbolFrames/Site.scss
@@ -160,7 +160,7 @@ html, body {
   bottom: 20px;
   left: 20px;
   width: 122px;
-  padding: 1px 10px;
+  padding: 2px 10px;
   border-radius: 2px;
   background-color: rgb(139, 134, 134);
   color: white;

--- a/Content/Styles/Symbols/Site.scss
+++ b/Content/Styles/Symbols/Site.scss
@@ -195,15 +195,6 @@ html, body {
   width: 100%;
 }
 
-// .stemContainer::before {
-//   @include lang-symbol(20px, "\f005 Español\00a0\00a0\00a0\00a0\f0c8 English");
-//   @extend %spanish-english;
-//   position: relative;
-//   top: 15px;
-//   left: 84%;
-//   text-transform: uppercase;
-// }
-
 .bigTable {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
Reformats frame titles in Hybrid: Frames and Indicators and Hybrid: Frames and Lines formats to better match the mockups with the createFrameTitles function. Also, removes commented out code in the Symbols format's SCSS file.