### PR TITLE
fix(toggle): toggle pages no longer scroll to the bottom of the page

### DIFF
--- a/Views/Shared/_Item3318.cshtml
+++ b/Views/Shared/_Item3318.cshtml
@@ -98,21 +98,39 @@
                                                                 left: 33px;
                                                             }
 
+                                                            .loading {
+                                                                pointer-events: none;
+                                                            }
+
                                                             #graphic-en {
                                                                 position:relative;
                                                                 top:-507px;
                                                                 float: center;
                                                             }
                                                         </style>
-                                                        <div id="graphic-sp"> 
-                                                        <iframe src="~/Content/Graphic/item-187-3318-graphic-SP.html" scolling="no">
+                                                        <script>
+                                                            window.addEventListener('scroll', startup);
+                                                            document.getElementsByTagName('body')[0].classList.add('loading');
+                                                            var numScroll = 0;
+                                                            function startup(e){
+                                                                numScroll++;
+                                                                window.scroll(0, 0);
+                                                                if(numScroll > 2){
+                                                                    window.removeEventListener('scroll', startup);
+                                                                    document.getElementsByTagName('body')[0].classList.remove('loading');
+                                                                }
+                                                            }
+                                                        </script>
+
+                                                        <div id="graphic-sp" class="loading"> 
+                                                        <iframe id="graphic-sp-iframe" src="~/Content/Graphic/item-187-3318-graphic-SP.html" scolling="no">
                                                             <p>
                                                                 Your browser does not support Iframes.
                                                             </p>
                                                         </iframe>
                                                         </div>
-                                                        <div id="graphic-en" class="hidden">
-                                                        <iframe src="~/Content/Graphic/item-187-3318-graphic-EN.html" scolling="no">
+                                                        <div id="graphic-en" class="hidden loading">
+                                                        <iframe id="graphic-en-iframe" src="~/Content/Graphic/item-187-3318-graphic-EN.html" scolling="no">
                                                             <p>
                                                                 Your browser does not support Iframes.
                                                             </p>

--- a/Views/Shared/_Item3561.cshtml
+++ b/Views/Shared/_Item3561.cshtml
@@ -109,22 +109,41 @@
                                                                 position: relative;
                                                             }
 
+                                                            .loading {
+                                                                pointer-events: none;
+                                                            }
+
                                                             #graphic-en {
-                                                                position: relative;
+                                                                
+                                                                position:relative;
                                                                 top: -497px;
-                                                                float:center;
+                                                                display: inline;
                                                             }
                                                         </style>
+                                                        <script>
+                                                            window.addEventListener('scroll', startup);
+                                                            document.getElementsByTagName('body')[0].classList.add('loading');
+                                                            var numScroll = 0;
+                                                            function startup(e){
+                                                                numScroll++;
+                                                                window.scroll(0, 0);
+                                                                if(numScroll > 2){
+                                                                    window.removeEventListener('scroll', startup);
+                                                                    document.getElementsByTagName('body')[0].classList.remove('loading');
+                                                                }
+                                                            }
+                                                        </script>
+
                                                         <p>&nbsp;</p>
                                                         <div id="graphic-sp">
-                                                        <iframe src="~/Content/Graphic/item-187-3561-graphic-SP.html">
+                                                        <iframe id='graphic-sp-iframe' src="~/Content/Graphic/item-187-3561-graphic-SP.html">
                                                             <p>
                                                                 Your Browser does not support Iframes.
                                                             </p>
                                                         </iframe>
                                                         </div>
                                                         <div id="graphic-en" class="hidden">
-                                                        <iframe src="~/Content/Graphic/item-187-3561-graphic-EN.html">
+                                                        <iframe id="graphic-en-iframe" src="~/Content/Graphic/item-187-3561-graphic-EN.html">
                                                             <p>
                                                                 Your Browser does not support Iframes.
                                                             </p>

--- a/Views/Shared/_Item3593.cshtml
+++ b/Views/Shared/_Item3593.cshtml
@@ -59,11 +59,30 @@
 																overflow: hidden;
 																position: relative;
 															}
+
+															.loading {
+																pointer-events: none;
+															}
+
 															#graphic-en {
 																position: relative;
 																bottom: 259px;
 															}
 														</style>
+
+														<script>
+															window.addEventListener('scroll', startup);
+                                                            document.getElementsByTagName('body')[0].classList.add('loading');
+                                                            var numScroll = 0;
+                                                            function startup(e){
+                                                                numScroll++;
+                                                                window.scroll(0, 0);
+                                                                if(numScroll > 2){
+                                                                    window.removeEventListener('scroll', startup);
+                                                                    document.getElementsByTagName('body')[0].classList.remove('loading');
+                                                                }
+                                                            }
+														</script>
 														<div id="graphic-sp">
 														<iframe id="graphic-sp" src="~/Content/Graphic/item-187-3593-graphic-SP.html" scrolling="no">
 															<p>Your browser does not support Iframes</p>


### PR DESCRIPTION
fixes issue with toggle scrolling when GI is loaded. This solution is not great but given that IVS throws a non cancel-able event this is the best I think we can do.