### PR TITLE
Fix Body Font Family

### DIFF
--- a/Content/Styles/Divided/Site.scss
+++ b/Content/Styles/Divided/Site.scss
@@ -27,6 +27,7 @@ body {
   height: 100%;
   width: 100%;
   font-family: "Times New Roman", Times, serif;
+  font-size: 16px;
 }
 
 %spanish-english-shared {

--- a/Content/Styles/DividedFrames/Site.scss
+++ b/Content/Styles/DividedFrames/Site.scss
@@ -27,6 +27,7 @@ body {
   height: 100%;
   width: 100%;
   font-family: "Times New Roman", Times, serif;
+  font-size: 16px;
 }
 
 .spanish,

--- a/Content/Styles/Shared/Navbar.scss
+++ b/Content/Styles/Shared/Navbar.scss
@@ -51,6 +51,7 @@ $out: '\f010';
 
 .topnav .link {
   font-size: 18px;
+  font-family: PT Sans, Helvetica Neue, Helvetica, Arial, sans-serif;
   color: #007393;
   margin: 10px 20px;
   white-space: nowrap;
@@ -188,7 +189,3 @@ body {
 #grid{
   margin-top:50px;
 } 
-
-html *{
-  font-family: sans-serif;
-}

--- a/Content/Styles/Stacked/Site.scss
+++ b/Content/Styles/Stacked/Site.scss
@@ -136,7 +136,7 @@ html,
 body {
   height: 100%;
   width: 100%;
-  font-family: "Times New Roman", Times, serif !important;
+  font-family: "Times New Roman", Times, serif;
   font-size: 16px;
 }
 

--- a/Content/Styles/Stacked/Site.scss
+++ b/Content/Styles/Stacked/Site.scss
@@ -136,7 +136,8 @@ html,
 body {
   height: 100%;
   width: 100%;
-  font-family: "Times New Roman", Times, serif;
+  font-family: "Times New Roman", Times, serif !important;
+  font-size: 16px;
 }
 
 .center {

--- a/Content/Styles/SymbolFrames/Site.scss
+++ b/Content/Styles/SymbolFrames/Site.scss
@@ -35,6 +35,7 @@ body {
   height: 100%;
   width: 100%;
   font-family: "Times New Roman", Times, serif;
+  font-size: 16px;
   margin: 0px;
   padding: 0px;
   overflow-x: hidden;

--- a/Content/Styles/Symbols/Site.scss
+++ b/Content/Styles/Symbols/Site.scss
@@ -34,6 +34,7 @@ html, body {
   height: 100%;
   width: 100%;
   font-family: 'Times New Roman', Times, serif;
+  font-size: 16px;
 }
 
 %spanish-english {

--- a/Content/Styles/Toggle/Site.scss
+++ b/Content/Styles/Toggle/Site.scss
@@ -152,6 +152,7 @@ body {
   height: 100%;
   width: 100%;
   font-family: "Times New Roman", Times, serif;
+  font-size: 16px;
 }
 
 input[type="text"] {


### PR DESCRIPTION
- Changes font family in the body of all formats to serif from sans serif.
- Increases body font size to 16px to improve readability.
- Changes nav bar SCSS to keep sans serif font family for all of its links (i.e. Home).