### PR TITLE
fix(gi items): remove hight and width 100% from body

### DIFF
--- a/Content/Styles/Shared/Navbar.scss
+++ b/Content/Styles/Shared/Navbar.scss
@@ -92,11 +92,7 @@ $out: '\f010';
 .botnav a:hover {
   color: black;
 }
-html,
-body {
-  height: 100%;
-  width: 100%;
-}
+
 .hidden {
   visibility: hidden;
   z-index: 0;

--- a/Content/Styles/SymbolFrames/Site.scss
+++ b/Content/Styles/SymbolFrames/Site.scss
@@ -32,12 +32,9 @@ p {
 
 html,
 body {
-  height: 100%;
-  width: 100%;
   font-family: "Times New Roman", Times, serif;
   margin: 0px;
   padding: 0px;
-  overflow-x: hidden;
 }
 
 .spanish,

--- a/Views/Shared/_Item3318.cshtml
+++ b/Views/Shared/_Item3318.cshtml
@@ -122,14 +122,14 @@
                                                             }
                                                         </script>
 
-                                                        <div id="graphic-sp" class="loading"> 
+                                                        <div id="graphic-sp"> 
                                                         <iframe id="graphic-sp-iframe" src="~/Content/Graphic/item-187-3318-graphic-SP.html" scolling="no">
                                                             <p>
                                                                 Your browser does not support Iframes.
                                                             </p>
                                                         </iframe>
                                                         </div>
-                                                        <div id="graphic-en" class="hidden loading">
+                                                        <div id="graphic-en" class="hidden">
                                                         <iframe id="graphic-en-iframe" src="~/Content/Graphic/item-187-3318-graphic-EN.html" scolling="no">
                                                             <p>
                                                                 Your browser does not support Iframes.


### PR DESCRIPTION
This pr Resolves SED-137 and SED-138. As of this PR the Hybrid frames styles do not scroll when the GI items load. I've also fixed the interactivity issue with item 3318.